### PR TITLE
Update Customer.php

### DIFF
--- a/engine/Shopware/Models/Customer/Customer.php
+++ b/engine/Shopware/Models/Customer/Customer.php
@@ -1182,6 +1182,14 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
+     * @param int $languageId
+     */
+    public function setLanguageId($languageId)
+    {
+        $this->languageId = $languageId;
+    }
+    
+    /**
      * @return string
      */
     public function getLanguageId()

--- a/engine/Shopware/Models/Customer/Customer.php
+++ b/engine/Shopware/Models/Customer/Customer.php
@@ -1182,7 +1182,7 @@ class Customer extends LazyFetchModelEntity
     }
 
     /**
-     * @param int $languageId
+     * @param string $languageId
      */
     public function setLanguageId($languageId)
     {


### PR DESCRIPTION
Setter for languageId

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
Setter for languageId is missing in Api.
In the documentation is languageId set via post, but has no effect.

### 2. What does this change do, exactly?
sets languageId via api

### 3. Describe each step to reproduce the issue or behaviour.
post customer languageId to shop with different id than 1

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
No documentation changes needed, the documentation is correct but the endpoint is incorrect.

### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.